### PR TITLE
Update Vail parser to include following through the waitingroom

### DIFF
--- a/lib/lifts/index.js
+++ b/lib/lifts/index.js
@@ -49,12 +49,14 @@ function fetch(resort, fn) {
   debug("Fetch lift status for %s", resort.id);
   var rfau = resort._rfau;
   rfau.fn(rfau.url, resort._parseFn, function(err, data) {
-    if (err || !data) {
-      data = {};
-    }
-    fn(null, {
-      status: data,
-      stats: stats(data)
+    Promise.resolve(data).then(function(data, err) {
+      if (err || !data) {
+        data = {};
+      }
+      fn(null, {
+        status: data,
+        stats: stats(data)
+      });
     });
   });
 }

--- a/lib/lifts/request.js
+++ b/lib/lifts/request.js
@@ -8,6 +8,7 @@ process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
 module.exports = function (url) {
 
   return superagent
+    .agent()
     .get(url.host + url.pathname)
     .redirects(4)
     .query(url.query || '')

--- a/lib/resorts/wildcat/resort.json
+++ b/lib/resorts/wildcat/resort.json
@@ -1,7 +1,7 @@
 {
   "name": "Wildcat",
   "url": {
-    "host": "http://www.skiwildcat.com",
+    "host": "https://www.skiwildcat.com",
     "pathname": "/the-mountain/mountain-conditions/lift-and-terrain-status.aspx"
   },
   "tags": [

--- a/lib/tools/vail.js
+++ b/lib/tools/vail.js
@@ -4,9 +4,11 @@ var debug = require('debug')('liftie:resort:vail');
 var domutil = require('./domutil');
 var select = require('../select');
 
+var request = require('../lifts/request');
+var htmlparser = require('htmlparser2');
+
+
 module.exports = parse;
-
-
 
 var statuses = ['closed', 'open', 'hold'];
 
@@ -21,19 +23,48 @@ function extractLiftData(script) {
   return data && data.TerrainStatusFeed && data.TerrainStatusFeed.Lifts || [];
 }
 
-
-// common parser for Vail Resorts lift status
-function parse(dom) {
+function parseLiftStatus(dom) {
   var dataScript = select(dom, 'script')
-    .map(script => domutil.allText(script).trim())
-    .find(script => script.includes('TerrainStatusFeed = {'));
+      .map(script => domutil.allText(script).trim())
+      .find(script => script.includes('TerrainStatusFeed = {'));
 
   var liftStatus = extractLiftData(dataScript)
-    .reduce(function(liftStatus, lift) {
-      liftStatus[lift.Name.trim()] = statuses[lift.Status];
-      return liftStatus;
-    }, {});
+      .reduce(function (liftStatus, lift) {
+        liftStatus[lift.Name.trim()] = statuses[lift.Status];
+        return liftStatus;
+      }, {});
 
   debug('vail Lift Status:', liftStatus);
   return liftStatus;
+}
+
+function followWaitingRoom(waitingRoom) {
+  var pathParts = waitingRoom.split("'");
+  var redirectUrl = {
+    host: "https://waitingroom.snow.com",
+    pathname: pathParts[1]
+  };
+
+  return request(redirectUrl)
+      .on('error', function() { return {}; })
+      .then(function (res) {
+        if (!res.text) {
+          return {};
+        }
+        return parseLiftStatus(htmlparser.parseDOM(res.text));
+      });
+}
+
+// common parser for Vail Resorts lift status
+function parse(dom) {
+
+  var waitingRoom = select(dom, 'script')
+      .map(script => domutil.allText(script).trim())
+      .find(script => script.includes("document.location.href = '/?c=vailresorts"));
+
+  if (waitingRoom) {
+    return followWaitingRoom(waitingRoom);
+  } else {
+    return parseLiftStatus(dom);
+  }
 }


### PR DESCRIPTION
Checks if the page contains the document.location.href in a script tag, which is present on the page that is loaded when being sent to the waiting room. This part is mostly so that no changes are required if they choose to remove the waitingroom function. If a waitingroom is detected, we get the content of the page that is referenced in that tag and parse that data, returning the relevant lift statuses.

Two changes to the core:

lib/lifts/request.js: added agent(). This keeps session info to ensure cookies are kept when being kicked around by the waitingroom. Not sure if this will have other implications.

lib/lifts/request.js: added a Promise.resolve. Adding another request within the Vail parser means that a Promise is returned there. Adding the resolve means that the function will wait for the Promise to come through, if it is a promise at all, or continue nevertheless if it isn't a promise. This should ensure no other resorts are broken by this change.

Closes #36