### PR TITLE
Bretton Woods needs www in hostname

### DIFF
--- a/lib/resorts/brettonwoods/resort.json
+++ b/lib/resorts/brettonwoods/resort.json
@@ -1,7 +1,7 @@
 {
   "name": "Bretton Woods",
   "url": {
-    "host": "http://brettonwoods.com",
+    "host": "https://www.brettonwoods.com",
     "pathname": "/alpine_trails/trail_report"
   },
   "tags": [


### PR DESCRIPTION
It redirects from brettonwoods.com/anything to the homepage.