### PR TITLE
Potential fix for code scanning alert no. 140: Incomplete regular expression for hostnames

### DIFF
--- a/test/webcams.js
+++ b/test/webcams.js
@@ -47,7 +47,7 @@ test('webcams should return webcams', async t => {
 
         t.assert.equal(webcam.name, 'Fieschertal: Jungfraujoch');
         t.assert.equal(webcam.source, 'https://windy.com/webcams/1697038975');
-        t.assert.match(webcam.image, /^https:\/\/images-webcams.windy.com\//);
+        t.assert.match(webcam.image, /^https:\/\/images-webcams\.windy\.com\//);
         t.assert.match(webcam.notice, /^Webcams provided by\n<a href="https:\/\/www.windy.com\/"/);
 
         done();


### PR DESCRIPTION
Potential fix for [https://github.com/pirxpilot/liftie/security/code-scanning/140](https://github.com/pirxpilot/liftie/security/code-scanning/140)

In general, to fix incomplete hostname regular expressions, every literal dot (`.`) in a hostname should be escaped as `\.` so that it matches only a literal period instead of any character. This ensures that checks for domains like `example.com` do not also match `exampleXcom` or similar unintended hosts.

In this specific file, the best fix is to update the regular expression on line 50 so that `windy.com` is matched literally. That means changing `windy.com` to `windy\.com` while leaving the rest of the pattern unchanged. The expression currently is `^https:\/\/images-webcams.windy.com\/`; it should be `^https:\/\/images-webcams\.windy\.com\/`. This preserves the existing behavior (checking that the string starts with `https://images-webcams.windy.com/`) while making the host comparison precise. No additional imports or helper methods are necessary; only this one regex literal in `test/webcams.js` needs modification.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
