### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -1,4 +1,6 @@
 name: check
+permissions:
+  contents: read
 on: [push, pull_request, workflow_dispatch]
 jobs:
   build:


### PR DESCRIPTION
Potential fix for [https://github.com/pirxpilot/liftie/security/code-scanning/1](https://github.com/pirxpilot/liftie/security/code-scanning/1)

In general, the fix is to explicitly specify a `permissions` block that grants only the minimal scopes needed by this workflow. Since this job only checks out code, configures pnpm and Node, and runs `make`, it only needs read access to the repository contents (and possibly packages if your build pulls from GitHub Packages). The minimal safe default is to add `permissions: contents: read` at the workflow level (top-level key alongside `name` and `on`), which will apply to all jobs unless overridden. This documents the intended permissions and ensures the workflow remains least-privilege even if repository defaults are broader.

Concretely, in `.github/workflows/check.yaml`, add a top-level `permissions` block after the `name` and before `on` (or after `on`; location among top-level keys is flexible but we’ll insert after `name` for clarity). No imports or additional methods are needed because this is a YAML workflow file, not application code. The rest of the workflow remains unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
