### PR TITLE
resort: fix skiwelt - route JSON endpoint through api instead of dataUrl

### DIFF
--- a/lib/resorts/skiwelt/resort.json
+++ b/lib/resorts/skiwelt/resort.json
@@ -4,17 +4,6 @@
     "host": "https://www.skiwelt.at",
     "pathname": "/en/lift-status-winter.html"
   },
-  "dataUrl": {
-    "host": "https://www.skiwelt.at",
-    "pathname": "/webapi/micadoweb",
-    "query": {
-      "api": "Micado.Ski.Web/Micado.Ski.Web.IO.Api.FacilityApi/List.api",
-      "region": "skiwelt",
-      "season": "winter",
-      "typeIDs": 1
-    },
-    "json": true
-  },
   "tags": [
     "Alps",
     "Austria"
@@ -22,5 +11,15 @@
   "ll": [
     12.25,
     47.45
-  ]
+  ],
+  "api": {
+    "host": "https://www.skiwelt.at",
+    "pathname": "/webapi/micadoweb",
+    "query": {
+      "api": "Micado.Ski.Web/Micado.Ski.Web.IO.Api.FacilityApi/List.api",
+      "region": "skiwelt",
+      "season": "winter",
+      "typeIDs": 1
+    }
+  }
 }


### PR DESCRIPTION
dataUrl responses always go through the HTML parser, so the JSON parse function received a DOM and returned an empty map. The 'json' flag on dataUrl is not implemented anywhere in lib/.